### PR TITLE
Add unity api endpoint as parameter

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -13,7 +13,7 @@ end
 
 def bc
   client =
-    AllscriptsApi::Client.new(ENV["unity_url"],
+    AllscriptsApi::Client.new("http://twlatestga.unitysandbox.com/",
                               ENV["app_name"],
                               ENV["app_username"],
                               ENV["app_password"])

--- a/lib/allscripts_api.rb
+++ b/lib/allscripts_api.rb
@@ -46,13 +46,13 @@ module AllscriptsApi
 
     # The main entry point for a pre-configured client
     #
+    # @param unity_url [String] Unity API endpoint to connect to
     # @return [AllscriptsApi::Client, AllscriptsApi::NoConfigurationError]
     # @see AllscriptsApi::Client
-    def connect
+    def connect(unity_url)
       unless AllscriptsApi.configuration
         raise NoConfigurationError, NoConfigurationError.error_message
       end
-      unity_url = AllscriptsApi.configuration.unity_url
       app_name = AllscriptsApi.configuration.app_name
       app_username = AllscriptsApi.configuration.app_username
       app_password = AllscriptsApi.configuration.app_password

--- a/lib/allscripts_api/configuration.rb
+++ b/lib/allscripts_api/configuration.rb
@@ -8,12 +8,10 @@ module AllscriptsApi
   #   config.app_name = 'YOUR_APP_NAME_HERE'
   #   config.app_username = 'YOUR_APP_USERNAME_HERE'
   #   config.app_password = 'YOUR_APP_PASSWORD_HERE'
-  #   config.unity_url = 'CHOSEN_UNITY_URL'
   #   config.faraday_adapter = Faraday.some_adapter # default = Faraday.default_adapter
   # end
   class Configuration
-    attr_accessor :app_name, :app_password, :unity_url,
-                  :app_username, :faraday_adapter
+    attr_accessor :app_name, :app_password, :app_username, :faraday_adapter
     # The initialize method may be passed a block, but defaults to fetching
     # data from the environment
     #
@@ -21,7 +19,6 @@ module AllscriptsApi
     def initialize
       @app_name = ENV["app_name"]
       @app_password = ENV["app_password"]
-      @unity_url = ENV["unity_url"]
       @app_username = ENV["app_username"]
       @faraday_adapter = Faraday.default_adapter
     end

--- a/spec/allscripts_api_spec.rb
+++ b/spec/allscripts_api_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AllscriptsApi do
   end
 
   describe "#self.connect" do
-  let(:subject) { AllscriptsApi.connect }
+  let(:subject) { AllscriptsApi.connect("http://test.example") }
     context "without configuration" do
       it "raises an error" do
         expect { subject }.to raise_error(AllscriptsApi::NoConfigurationError)
@@ -15,7 +15,6 @@ RSpec.describe AllscriptsApi do
         AllscriptsApi.configure do |config|
           config.app_name = "Testy.McTestApp"
           config.app_password = "test1234"
-          config.unity_url = "http://test.example"
           config.app_username = "testy"
         end
       end
@@ -40,7 +39,6 @@ RSpec.describe AllscriptsApi do
       AllscriptsApi.configure do |config|
         config.app_name = "Testy.McTestApp"
         config.app_password = "test1234"
-        config.unity_url = "http://test.example"
         config.app_username = "testy"
       end
     end
@@ -49,7 +47,6 @@ RSpec.describe AllscriptsApi do
       subject
       expect(AllscriptsApi.configuration.app_name).to eq("Testy.McTestApp")
       expect(AllscriptsApi.configuration.app_password ).to eq("test1234")
-      expect(AllscriptsApi.configuration.unity_url ).to eq("http://test.example")
       expect(AllscriptsApi.configuration.app_username ).to eq("testy")
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,27 +3,28 @@ RSpec.describe AllscriptsApi::Configuration do
   describe "#new" do
     context "with env set" do
       before do 
-        ENV["unity_url"] ||= "http://twlatestga.unitysandbox.com/"
+        ENV["app_name"] ||= "Allscripts App Name"
       end
 
       let(:subject) { AllscriptsApi::Configuration.new }
 
       it "pulls configuration from the environment" do
-        expect(subject.unity_url).to eq(ENV["unity_url"])
+        expect(subject.app_name).to eq(ENV["app_name"])
       end
     end
 
     context "without the env set" do
       before do
-        ENV["unity_url"] = nil
+        @old_app_name = ENV["app_name"]
+        ENV["app_name"] = nil
       end
       after do
-        ENV["unity_url"] = "http://twlatestga.unitysandbox.com/"
+        ENV["app_name"] = @old_app_name
       end
       let(:subject) { AllscriptsApi::Configuration.new }
 
       it "configuration is nil" do
-        expect(subject.unity_url).to eq(nil)
+        expect(subject.app_name).to eq(nil)
       end
     end
   end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-# Checks te ENV with `check_env` to see if secrets are already set
+# Checks the ENV with `check_env` to see if secrets are already set
 # by this file or from an external source, e.g. CI. If they exist
 # a variable is set to prevent test skipping. If they are not present,
-# `load_yaml_to_env` attempts to load them from and YAML file, and sets
+# `load_yaml_to_env` attempts to load them from an YAML file, and sets
 # the flag as well.
 # If both cases fail, the flag is set to true so that tests attempting to
 # make api calls are skipped.
 #
-# NOTE: this does not protect against bag configuration or bad credentials.
+# NOTE: this does not protect against bad configuration or bad credentials.
 def check_and_load_secrets
   load_yaml_to_env unless check_env
   @no_secrets = false
@@ -23,7 +23,6 @@ end
 def check_env
   ENV["app_name"] &&
     ENV["app_password"] &&
-    ENV["unity_url"] &&
     ENV["app_username"]
 end
 
@@ -35,7 +34,7 @@ end
 
 def build_and_auth_client
   client =
-    AllscriptsApi::Client.new(ENV["unity_url"],
+    AllscriptsApi::Client.new("http://twlatestga.unitysandbox.com/",
                               ENV["app_name"],
                               ENV["app_username"],
                               ENV["app_password"])

--- a/spec/named_magic_methods_spec.rb
+++ b/spec/named_magic_methods_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe AllscriptsApi::NamedMagicMethods do
         "EntryName"=>"CPT",
         "Active"=>"Y"}
     end
-    
+
     context "with a valid name" do
       let(:dictionary_name) { "Code_Type_DE" }
 
@@ -185,3 +185,4 @@ RSpec.describe AllscriptsApi::NamedMagicMethods do
     end
   end
 end
+


### PR DESCRIPTION
This PR adds the ability for developers to dynamically pass in `unity_url` when calling `AllscriptsApi.connect`. This is important because the Unity API endpoint varies by Allscripts instance aka "account" in production.
